### PR TITLE
Enhancement/better-help

### DIFF
--- a/src/Saturn.Dotnet/Program.fs
+++ b/src/Saturn.Dotnet/Program.fs
@@ -611,27 +611,28 @@ let runMigration (extraArgv: string []) =
   startInfo.FileName <- "dotnet"
   startInfo.RedirectStandardOutput <- true
   startInfo.RedirectStandardError <- true
-  startInfo.RedirectStandardInput <-true
+  startInfo.RedirectStandardInput <- true
   startInfo.WorkingDirectory <- Directory.GetCurrentDirectory()
-  let processs = Process.Start(startInfo)
+  let processs = Process.Start startInfo
   let output = processs.StandardOutput.ReadToEnd()
   processs.WaitForExit()
   printfn "%s" output
 
 let printHelp () =
-    printfn """Avaliable commands:
-
-  * gen, gen.html - generates the model, data access layer, controller, and server side views
-  * gen.json - generates the model, data access layer, and controller returning data in JSON format
-  * gen.model - generates model, and data access layer without controller nor views
-  * migration - runs all migrations updating the database to the latest version
-  * interactive - [experimental] starts interactive mode to interactivly explore running application.
-
-"""
+  Console.ForegroundColor <- ConsoleColor.Cyan
+  printfn "Welcome to Saturn CLI. Avaliable commands:"
+  Console.ForegroundColor <- ConsoleColor.White
+  [
+    "* gen, gen.html", "generates the model, data access layer, controller, and server side views"
+    "* gen.json", "generates the model, data access layer, and controller returning data in JSON format"
+    "* gen.model", "generates model, and data access layer without controller nor views"
+    "* migration", "runs all migrations updating the database to the latest version"
+    "* interactive", "[experimental] starts interactive mode to interactivly explore running application"
+  ]
+  |> List.iter (fun (command, description) -> printfn "%-16s %s" command description)
 
 [<EntryPoint>]
 let main argv =
-
     match Array.tryHead argv |> Option.map (fun n -> n.ToLower()) with
     | Some action ->
         try
@@ -666,8 +667,6 @@ let main argv =
             printfn "---"
             printHelp ()
     | None ->
-        printfn "Missing input parameters - they should be passed in following format: Command Name Names [field_name:field_type]"
-        printfn "---"
         printHelp ()
 
     0 // return an integer exit code

--- a/src/Saturn.Dotnet/Program.fs
+++ b/src/Saturn.Dotnet/Program.fs
@@ -67,7 +67,6 @@ let (</>) a b = Path.Combine(a,b)
 let upper (s: string) =
     s |> Seq.mapi (fun i c -> match i with | 0 -> (Char.ToUpper(c)) | _ -> c)  |> String.Concat
 
-
 let generateFile (path, ctn) =
     let path = Path.GetFullPath path
     printfn "Generated %s ..." path
@@ -625,8 +624,8 @@ let printHelp () =
   * gen, gen.html - generates the model, data access layer, controller, and server side views
   * gen.json - generates the model, data access layer, and controller returning data in JSON format
   * gen.model - generates model, and data access layer without controller nor views
-  * migration - runs migration of database to latest version
-  * interactive - starts interactive mode that let's you interactivly explore running application. EXPERIMENTAL.
+  * migration - runs all migrations updating the database to the latest version
+  * interactive - [experimental] starts interactive mode to interactivly explore running application.
 
 """
 
@@ -656,6 +655,7 @@ let main argv =
             // | "gen.graphql" -> generateGraphQL name names fields
             | "migration" -> runMigration argv.[1 ..]
             | "interactive" -> Interactive.start (Directory.GetCurrentDirectory())
+            | "help" | "--help" | "-?" -> printHelp ()
             | _ ->
                 printfn "Wrong format of input parameters - they should be passed in following format: Command Name Names [field_name:field_type]"
                 printfn "---"

--- a/src/Saturn.Dotnet/Program.fs
+++ b/src/Saturn.Dotnet/Program.fs
@@ -621,13 +621,13 @@ let runMigration (extraArgv: string []) =
 let printHelp () =
   Console.ForegroundColor <- ConsoleColor.Cyan
   printfn "Welcome to Saturn CLI. Avaliable commands:"
-  Console.ForegroundColor <- ConsoleColor.White
+  Console.ResetColor ()
   [
-    "* gen, gen.html", "generates the model, data access layer, controller, and server side views"
-    "* gen.json", "generates the model, data access layer, and controller returning data in JSON format"
-    "* gen.model", "generates model, and data access layer without controller nor views"
-    "* migration", "runs all migrations updating the database to the latest version"
-    "* interactive", "[experimental] starts interactive mode to interactivly explore running application"
+    "* gen, gen.html", "generates the model, data access layer, controller and server side views"
+    "* gen.json", "generates the model, data access layer and controller returning data in JSON format"
+    "* gen.model", "generates the model and data access layer only"
+    "* migration", "runs all migrations, updating the database to the latest version"
+    "* interactive", "[experimental] starts interactive mode to interactively explore the running application"
   ]
   |> List.iter (fun (command, description) -> printfn "%-16s %s" command description)
 


### PR DESCRIPTION
After starting with Saturn I found the CLI a little rough around the edges. Since the CLI is one of the first touch points with Saturn and something users of the framework will utilise, the experience should be friendly, clear and concise.

### Changes Made
- Added welcome text and a splash of colour.
- Cleared up some language used in the help menu.
- Added handling for `--help` `help` and `-?` commands. A common goto for understanding a CLI is invoking one of these and it initially threw me off that I was just getting an error message.
- Added table formatting for the command list. Again just makes it a nicer experience.
- Calling `dotnet Saturn` with no parameters should just give you the list of available commands instead of presenting you with an error.

I'm happy to work on and iterate on any of these changes with the maintainers.