### PR TITLE
Allow CLI tool to roll forward to later runtimes

### DIFF
--- a/src/Saturn.Cli/Saturn.Cli.fsproj
+++ b/src/Saturn.Cli/Saturn.Cli.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>saturn</ToolCommandName>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />


### PR DESCRIPTION
allowng roll forward to later runtimes means we don't have to update the tool TFM for .NET 7 and beyond.